### PR TITLE
Update README.md with link to live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What is this?
 
-It's a really simple ServiceWorker example. No build systems, (almost) no dependencies. It's designed to be an interactive introduction to the kinds of things you can do with ServiceWorker.
+It's a really [simple ServiceWorker example](https://jakearchibald.github.io/simple-serviceworker-tutorial/). No build systems, (almost) no dependencies. It's designed to be an interactive introduction to the kinds of things you can do with ServiceWorker.
 
 ## 1. Get it running locally
 


### PR DESCRIPTION
If you type in the demo URL without the protocol, Github redirects you to the HTTP version which means the ServiceWorker doesn't work. That's why a link in the README with the HTTPS protocol might save some people a headache.
