### PR TITLE
Include http-server as dev dep and start using `npm start`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Either clone it via git, or just [grab the zip file](https://github.com/jakearch
 If you already run a web server locally, put the files there. Or you can run a web server from the terminal for the current directory by installing [node.js](http://nodejs.org/) and running:
 
 ```sh
-npm install http-server -g
-http-server -c-1
+npm install
+npm start
 ```
 
 Visit the site in Chrome (`http://localhost:8080` if you used the script above). Open the dev tools and look at the console. Once you refresh the page, it'll be under the ServiceWorker's control.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simple-serviceworker-tutorial",
+  "private": true,
+  "scripts": {
+    "start": "http-server -c-1"
+  },
+  "devDependencies": {
+    "http-server": "0.8.5"
+  }
+}


### PR DESCRIPTION
This way you don't have to install http-server globally and you can just start the server using the conventional `npm start` which hides the implementation (`http-server -c-1`).

Note: I'm not sure if gh-pages is the proper place to put these kind of files in. But it's pratical.
